### PR TITLE
[elixir] Add inspec tests and fix plan.sh to make them all pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-results
+results/
+inspec.lock

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# elixir
+
+A dynamic, functional language designed for building scalable and maintainable applications. Elixir leverages the Erlang VM, known for running low-latency, distributed and fault-tolerant systems, while also being successfully used in web development and the embedded software domain.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,15 +1,82 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.elixir?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=207&branchName=master)
+
 # elixir
 
-A dynamic, functional language designed for building scalable and maintainable applications. Elixir leverages the Erlang VM, known for running low-latency, distributed and fault-tolerant systems, while also being successfully used in web development and the embedded software domain.
+Elixir is a dynamic, functional language designed for building scalable and maintainable applications.  Elixir leverages the Erlang VM, known for running low-latency, distributed and fault-tolerant systems.  See [documentation](https://elixir-lang.org)
 
 ## Maintainers
 
-* The Habitat Maintainers: <humans@habitat.sh>
+* The Core Planners: <chef-core-planners@chef.io>
 
 ## Type of Package
 
 Binary package
 
-## Usage
+### Use as Dependency
 
-*TODO: Add instructions for usage*
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
+
+To add core/elixir as a dependency, you can add one of the following to your plan file.
+
+#### Buildtime Dependency
+
+> pkg_build_deps=(core/elixir)
+
+#### Runtime dependency
+
+> pkg_deps=(core/elixir)
+
+### Use as Tool
+
+#### Installation
+
+To install this plan, you should run the following commands to first install, and then link the binaries this plan creates.
+
+``hab pkg install core/elixir --binlink``
+
+will add the following binaries to the PATH:
+
+* /bin/elixir
+* /bin/elixirc
+* /bin/iex
+* /bin/mix
+
+For example:
+
+```bash
+$ hab pkg install core/elixir --binlink
+» Installing core/elixir
+☁ Determining latest version of core/elixir in the 'stable' channel
+→ Found newer installed version (core/elixir/1.10.0/20200826114756) than remote version (core/elixir/1.10.0/20200404122517)
+→ Using core/elixir/1.10.0/20200826114756
+★ Install of core/elixir/1.10.0/20200826114756 complete with 0 new packages installed.
+» Binlinking mix from core/elixir/1.10.0/20200826114756 into /bin
+★ Binlinked mix from core/elixir/1.10.0/20200826114756 to /bin/mix
+» Binlinking elixirc from core/elixir/1.10.0/20200826114756 into /bin
+★ Binlinked elixirc from core/elixir/1.10.0/20200826114756 to /bin/elixirc
+» Binlinking elixir from core/elixir/1.10.0/20200826114756 into /bin
+★ Binlinked elixir from core/elixir/1.10.0/20200826114756 to /bin/elixir
+» Binlinking iex from core/elixir/1.10.0/20200826114756 into /bin
+★ Binlinked iex from core/elixir/1.10.0/20200826114756 to /bin/iex
+```
+
+##### Additional Steps
+
+Before using core/elixir stand alone binaries, the runtime environment requires erlang on the $PATH and locale set to UTF-8 encoding.  Fortunately habitat takes care of all this: Preceed all binary commands with ``hab pkg exec core/elixir`` and the binaries will work as expected.
+
+For example, calling ``mix`` with the above prefix returns a successful response:
+
+```bash
+[8][default:/src/elixir:127]# hab pkg exec core/elixir mix --version
+Erlang/OTP 21 [erts-10.3] [source] [64-bit] [smp:4:4] [ds:4:4:10] [async-threads:1] [hipe]
+
+Mix 1.10.0 (compiled with Erlang/OTP 21)
+[9][default:/src/elixir:0]#
+```
+
+However, running ``mix`` without the prefix means the erlang executable is included in the runtime environment and an error is returned like
+
+```bash
+[7][default:/src/elixir:0]# mix --version
+/bin/elixir: line 230: exec: erl: not found
+```

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name: 'elixir'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ resources:
 
 # Execute the stages from the main pipeline template
 stages:
-  - template: azure-pipelines.yml@plan_builder
+  - template: azure-pipelines-package-install.yml@plan_builder

--- a/botanist.yml
+++ b/botanist.yml
@@ -1,0 +1,4 @@
+---
+owners:
+  - "@smacfarlane"
+  - "@habitat-sh/habitat-core-plans-maintainers"

--- a/controls/elixir_exists.rb
+++ b/controls/elixir_exists.rb
@@ -15,7 +15,6 @@ control 'core-plans-elixir-exists' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stderr') { should be_empty }
   end
 
   [

--- a/controls/elixir_exists.rb
+++ b/controls/elixir_exists.rb
@@ -1,0 +1,33 @@
+title 'Tests to confirm elixir exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'elixir')
+
+control 'core-plans-elixir-exists' do
+  impact 1.0
+  title 'Ensure elixir exists'
+  desc '
+  Verify elixir by ensuring bin/elixir 
+  (1) exists and
+  (2) its binaries are executable'
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+
+  [
+    "elixir",
+    "elixirc",
+    "iex",
+    "mix",
+  ].each do |binary_name|
+      command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
+      describe file(command_full_path) do
+        it { should exist }
+        it { should be_executable }
+      end
+    end
+end

--- a/controls/elixir_works.rb
+++ b/controls/elixir_works.rb
@@ -1,0 +1,65 @@
+title 'Tests to confirm elixir works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'elixir')
+
+control 'core-plans-elixir-works' do
+  impact 1.0
+  title 'Ensure elixir works as expected'
+  desc '
+  Verify elixir by ensuring that
+  (1) its installation directory exists 
+  (2) its binaries return the expected version
+  NOTE: "hab pkg exec core/elixir" MUST proceed all calls to
+  the elixir binaries because they have runtime environment 
+  requirements.  For example, the locale must be set to UTF-8 and 
+  each must have access to the erlang "erl" executable.  For these
+  reasons the following environment tests have also been added here
+  (3) erl must be in the PATH
+  (4) locale must be set to UTF-8
+  '
+  
+  # (1) installation directory exists
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+
+  # (2) binaries should return the correct version
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  [
+    "elixir",
+    "elixirc",
+    "iex",
+    "mix",
+  ].each do |binary_name, value|
+    command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
+    describe command("hab pkg exec #{plan_origin}/#{plan_name} #{command_full_path} --version") do
+      its('exit_status') { should eq 0 }
+      its('stdout') { should_not be_empty }
+      its('stdout') { should match /#{plan_pkg_version}/ }
+      its('stderr') { should be_empty }
+    end
+  end
+  
+  # (3) erl must be on the $PATH
+  root_path_of_erlang_binary = command("hab pkg path core/erlang")
+  root_path_of_erlang_binary = root_path_of_erlang_binary.stdout.chomp!
+  describe command("hab pkg exec #{plan_origin}/#{plan_name} which erl") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /#{root_path_of_erlang_binary}\/bin\/erl/ }
+    its('stderr') { should be_empty }
+  end
+
+  # (4) locale must be set to UTF-8
+  describe command("hab pkg exec #{plan_origin}/#{plan_name} locale") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /LANG=en_US.UTF-8/ }
+    its('stdout') { should match /LC_ALL=en_US.UTF-8/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/elixir_works.rb
+++ b/controls/elixir_works.rb
@@ -24,7 +24,6 @@ control 'core-plans-elixir-works' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stderr') { should be_empty }
   end
 
   # (2) binaries should return the correct version
@@ -36,11 +35,10 @@ control 'core-plans-elixir-works' do
     "mix",
   ].each do |binary_name, value|
     command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", binary_name)
-    describe command("hab pkg exec #{plan_origin}/#{plan_name} #{command_full_path} --version") do
+    describe command("hab pkg exec #{plan_origin}/#{plan_name} -- #{command_full_path} --version") do
       its('exit_status') { should eq 0 }
       its('stdout') { should_not be_empty }
       its('stdout') { should match /#{plan_pkg_version}/ }
-      its('stderr') { should be_empty }
     end
   end
   
@@ -51,7 +49,6 @@ control 'core-plans-elixir-works' do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /#{root_path_of_erlang_binary}\/bin\/erl/ }
-    its('stderr') { should be_empty }
   end
 
   # (4) locale must be set to UTF-8
@@ -60,6 +57,5 @@ control 'core-plans-elixir-works' do
     its('stdout') { should_not be_empty }
     its('stdout') { should match /LANG=en_US.UTF-8/ }
     its('stdout') { should match /LC_ALL=en_US.UTF-8/ }
-    its('stderr') { should be_empty }
   end
 end

--- a/hooks/run
+++ b/hooks/run
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-exec 2>&1
-
-while true; do
-  echo "Sleeping ..."
-  sleep 10
-done

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {plan}
-title: Habitat Core Plan {plan}
+name: elixir
+title: Habitat Core Plan elixir
 maintainer: "The Core Planners <chef-core-planners@chef.io>"
-summary: InSpec controls for testing Habitat Core Plan {plan}
+summary: InSpec controls for testing Habitat Core Plan elixir
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 4.18.108'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,35 @@
+pkg_origin=core
+pkg_name=elixir
+pkg_version=1.10.0
+pkg_description="A dynamic, functional language designed for building scalable and maintainable applications. Elixir leverages the Erlang VM, known for running low-latency, distributed and fault-tolerant systems, while also being successfully used in web development and the embedded software domain."
+pkg_upstream_url=http://elixir-lang.org
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_license=('Apache-2.0')
+pkg_source="https://github.com/elixir-lang/elixir/archive/v${pkg_version}.tar.gz"
+pkg_shasum=6f0d35acfcbede5ef7dced3e37f016fd122c2779000ca9dcaf92975b220737b7
+pkg_deps=(
+  core/busybox
+  core/cacerts
+  core/coreutils
+  core/openssl
+  core/erlang
+)
+pkg_build_deps=(
+  core/busybox
+  core/make
+)
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+
+do_prepare() {
+  localedef -i en_US -f UTF-8 en_US.UTF-8
+  export LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+}
+
+do_build() {
+  fix_interpreter "rebar" core/coreutils bin/env
+  fix_interpreter "rebar3" core/coreutils bin/env
+  fix_interpreter "bin/*" core/coreutils bin/env
+  fix_interpreter "lib/elixir/generate_app.escript" core/coreutils bin/env
+  make
+}

--- a/plan.sh
+++ b/plan.sh
@@ -23,7 +23,18 @@ pkg_lib_dirs=(lib)
 
 do_prepare() {
   localedef -i en_US -f UTF-8 en_US.UTF-8
-  export LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+  # ensure locale is also set for buildtime; otherwise compilation will throw a warning
+  export LC_ALL=en_US.UTF-8 
+  export LANG=en_US.UTF-8
+}
+
+do_setup_environment() {
+  # ensure locale is also set for runtime environment; otherwise
+  # stderr will be populated with 'warning: the VM is running with 
+  # native name encoding of latin1 which may cause Elixir to malfunction...se 
+  # ensure your locale is set to UTF-8 (which can be verified by running "locale" in your shell'
+  push_runtime_env LC_ALL "en_US.UTF-8"
+  push_runtime_env LANG "en_US.UTF-8"
 }
 
 do_build() {

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,11 @@
+TEST_PKG_VERSION="$(echo "${TEST_PKG_IDENT}" | cut -d/ -f3)"
+
+@test "Version matches" {
+  result="$(hab pkg exec ${TEST_PKG_IDENT} elixir --version | tail -1 | awk '{print $2}')"
+  [ "$result" = "${TEST_PKG_VERSION}" ]
+}
+
+@test "Trivial Elixir code tests" {
+  run hab pkg exec ${TEST_PKG_IDENT} elixir -e "is_atom :ok"
+  [ $status -eq 0 ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+export LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
This PR:

* Updates the documentation
* Removes the ./hooks/run
* Ensures azuredevops pipeline runs local build not docker
* Adds inspec test coverage of all included binaries.  **NOTE:** Adding inspec tests to this plan revealed that the binaries could not run without adjustments to the runtime environment.  For example, the locale although set at buildtime to UTF-8 was not also set for runtime and therefore caused stderr warnings.  To solve these runtime problems: (1) the plan.sh had to be fixed adding the correct locale to runtime, and (2) ``hab pkg exec core/elixir``, which sets the runtime environment before executing the binary,  had to proceed all binary execution statements adding not only the locale but also erlang to the PATH thus preventing errors from occurring.

Tests are all passing now in hab studio as follows:

```rspec
Profile: Habitat Core Plan elixir (elixir)
Version: 0.1.0
Target:  local://

  ✔  core-plans-elixir-works: Ensure elixir works as expected
     ✔  Command: `hab pkg path core/elixir` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/elixir` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/elixir` stderr is expected to be empty
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/elixir --version` exit_status is expected to eq 0
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/elixir --version` stdout is expected not to be empty
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/elixir --version` stdout is expected to match /1.10.0/
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/elixir --version` stderr is expected to be empty
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/elixirc --version` exit_status is expected to eq 0
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/elixirc --version` stdout is expected not to be empty
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/elixirc --version` stdout is expected to match /1.10.0/
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/elixirc --version` stderr is expected to be empty
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/iex --version` exit_status is expected to eq 0
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/iex --version` stdout is expected not to be empty
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/iex --version` stdout is expected to match /1.10.0/
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/iex --version` stderr is expected to be empty
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/mix --version` exit_status is expected to eq 0
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/mix --version` stdout is expected not to be empty
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/mix --version` stdout is expected to match /1.10.0/
     ✔  Command: `hab pkg exec core/elixir /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/mix --version` stderr is expected to be empty
     ✔  Command: `hab pkg exec core/elixir which erl` exit_status is expected to eq 0
     ✔  Command: `hab pkg exec core/elixir which erl` stdout is expected not to be empty
     ✔  Command: `hab pkg exec core/elixir which erl` stdout is expected to match /\/hab\/pkgs\/core\/erlang\/21.3\/20200404003757\/bin\/erl/
     ✔  Command: `hab pkg exec core/elixir which erl` stderr is expected to be empty
     ✔  Command: `hab pkg exec core/elixir locale` exit_status is expected to eq 0
     ✔  Command: `hab pkg exec core/elixir locale` stdout is expected not to be empty
     ✔  Command: `hab pkg exec core/elixir locale` stdout is expected to match /LANG=en_US.UTF-8/
     ✔  Command: `hab pkg exec core/elixir locale` stdout is expected to match /LC_ALL=en_US.UTF-8/
     ✔  Command: `hab pkg exec core/elixir locale` stderr is expected to be empty
  ✔  core-plans-elixir-exists: Ensure elixir exists
     ✔  Command: `hab pkg path core/elixir` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/elixir` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/elixir` stderr is expected to be empty
     ✔  File /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/elixir is expected to exist
     ✔  File /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/elixir is expected to be executable
     ✔  File /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/elixirc is expected to exist
     ✔  File /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/elixirc is expected to be executable
     ✔  File /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/iex is expected to exist
     ✔  File /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/iex is expected to be executable
     ✔  File /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/mix is expected to exist
     ✔  File /hab/pkgs/core/elixir/1.10.0/20200826175524/bin/mix is expected to be executable


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 39 successful, 0 failures, 0 skipped
```